### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,9 +5,11 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
     timeout-minutes: 15
     steps:
-      - uses: suzuki-shunsuke/go-autofix-action@ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12
+      - uses: suzuki-shunsuke/go-autofix-action@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13
         with:
           aqua_version: v2.59.1
+          takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
       go-version-file: go.mod
       aqua_policy_allow: true
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,12 +1,19 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard (Go variant) into the GitHub Actions workflows.

## Changes

- `.github/workflows/release.yaml` (go-release-workflow call): added `secrets:` block passing `TAKUMI_GUARD_BOT_ID`.
- `.github/workflows/workflow_call_test.yaml` (go-test-full-workflow call): bumped `uses:` ref `v5.0.2` → `v6.0.0` (`98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb`); declared `TAKUMI_GUARD_BOT_ID` as a required secret under `on.workflow_call.secrets`; added `secrets:` block passing the secret; added `id-token: write` to the `test` job permissions.
- `.github/workflows/test.yaml` (parent calling the reusable workflow locally): added `secrets:` block passing `TAKUMI_GUARD_BOT_ID`; added `id-token: write` to the `test` job permissions.
- `.github/workflows/autofix.yaml` (go-autofix-action): bumped action ref `v0.1.12` → `v0.1.13` (`9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e`); added input `takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}`; added `id-token: write` to the `autofix` job permissions.

## Note

The reusable go-test-full-workflow ref bump crossed a MAJOR version (v5.0.2 → v6.0.0).

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository (or organization) for these workflows to function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)