### PR TITLE
fix: disable the deprecated gomodguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - exhaustruct_v5
     - godot
     - godox
+    - gomodguard
     - ireturn
     - lll
     - nlreturn


### PR DESCRIPTION
golangci-lint prints this on every run:

```
level=warning msg="The linter 'gomodguard' is deprecated (since v2.12.0) due to: new major version. Replaced by gomodguard_v2."
level=warning msg="Suggested new configuration:\nlinters:\n  enable:\n    - gomodguard_v2\n"
```

This config uses `default: all`, so both `gomodguard` and `gomodguard_v2` are enabled and the deprecated one warns each time. Disabling the old name leaves `gomodguard_v2` running — the same shape as the existing `exhaustruct` / `exhaustruct_v5` and `wsl` / `wsl_v5` pairs in this list.

Nothing behavioural changes: neither linter is configured with allowed or blocked modules here, so both are no-ops today. This only removes the warning and makes the config say what is actually wanted.

Verified locally with golangci-lint v2.13.0: the warning is gone and the run still reports 0 issues.
